### PR TITLE
Added support for balancer class.

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -23,3 +23,4 @@ pub const DEFAULT_LB_ALGORITHM: &str = "least-connections";
 pub const DEFAULT_LB_BALANCER_TYPE: &str = "lb11";
 
 pub const FINALIZER_NAME: &str = "robotlb/finalizer";
+pub const ROBOTLB_LB_CLASS: &str = "robotlb";

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,6 +134,17 @@ pub async fn reconcile_service(
         return Err(RobotLBError::SkipService);
     }
 
+    let lb_type = svc
+        .spec
+        .as_ref()
+        .and_then(|s| s.load_balancer_class.as_ref())
+        .map(String::as_str)
+        .unwrap_or(consts::ROBOTLB_LB_CLASS);
+    if lb_type != consts::ROBOTLB_LB_CLASS {
+        tracing::debug!("Load balancer class is not robotlb. Skipping...");
+        return Err(RobotLBError::SkipService);
+    }
+
     tracing::info!("Starting service reconcilation");
 
     let lb = LoadBalancer::try_from_svc(&svc, &context)?;


### PR DESCRIPTION
Now if you specify a `loadBalancerClass` it won't be reconciling a service, unless the `loadBalancerClass` is `robotlb`.